### PR TITLE
Update ipAddress according to warning message

### DIFF
--- a/mkRouter.nix
+++ b/mkRouter.nix
@@ -22,8 +22,10 @@ in
   networking.nat.internalIPs = [ ipRange ];
   networking.nat.externalInterface = externalInterface;
   networking.interfaces."${internalInterface}" = { 
-    ipAddress = gatewayIP;
-    prefixLength = 24;
+    ipv4.addresses = [{
+      address = gatewayIP;
+      prefixLength = 24;
+    }];
   };
 
   services.dhcpd4 = let


### PR DESCRIPTION
I was getting the following warning:

```
trace: warning: The option `ipAddress' defined in `/etc/nixos/configuration.nix' has been changed to `ipv4.addresses' that has a different type. Please read `ipv4.addresses' documentation and update your configuration accordingly.
trace: warning: The option `prefixLength' defined in `/etc/nixos/configuration.nix' has been changed to `ipv4.addresses' that has a different type. Please read `ipv4.addresses' documentation and update your configuration accordingly.
```

I made the change in this commit & that warning disappeared.

I'm no expert, I just followed the instructions from the warning message + docs. What do you think?

Oliver